### PR TITLE
Fix Travis url in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@
 .. image:: https://pypip.in/license/QtAwesome/badge.svg
 
 .. image:: https://travis-ci.org/spyder-ide/QtAwesome.svg?branch=master
-   :target: https://travis-ci.org/spyder-ide/QtAwesome
+   :target: https://travis-ci.org/spyder-ide/qtawesome
    :alt: Travis-CI build status
 
 QtAwesome - Iconic Fonts in PyQt and PySide applications


### PR DESCRIPTION
I don't know why you selected camel case for the project name on PyPi, etc, (I really don't like it) but @SylvainCorlay agreed with a lower case name for the repo ;-)