### PR TITLE
Enable qt5 testting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ env:
 matrix:
   include:
     # Linux
-    #- python: "2.7"
-    #  env: USE_QT_API=PyQt5
-    #  os: linux
+    - python: "2.7"
+      env: USE_QT_API=PyQt5
+      os: linux
     - python: "2.7"
       env: USE_QT_API=PyQt4
       os: linux


### PR DESCRIPTION
I disable qt5 testing in master since I want to push up a new version in pip. This PR re-enables it. 