### PR TITLE
Add a conda recipe to the tree

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+$PYTHON setup.py install

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: qtawesome
+  version: 0.1.8.post1
+
+source:
+  git_url: ../
+  git_tag: a9e3d1e
+
+build:
+  noarch_python: True
+
+requirements:
+  build:
+    - python
+    - six
+    - qtpy
+  run:
+    - python
+    - qtpy
+    - six
+
+test:
+  imports:
+    - qtawesome
+  requires:
+    - pyqt
+
+about:
+  home: https://github.com/spyder-ide/qtawesome
+  license: MIT
+  summary: Iconic fonts in PyQt and PySide applications


### PR DESCRIPTION
Some notes to @SylvainCorlay and @goanpeca:

1. I decided to remove Qtawesome from Spyder source tree (see spyder-ide/spyder#2831) because Qtawesome depends on six while Spyder doesn't. That's a hidden dependency problem that can be fixed by making Qtawesome a proper Spyder dep (which is my plan in 2831).
2. That's why I need a conda package for Qtawesome :-)
2. Please do a new release of Qtawesome to account for the problems you fixed in OS X. I made the current recipe to depend on the commit where PR #27 was merged, but it'd be nicer to just have a new release.
3. Please tag your releases :-) There's not a single tag in this repo!