### PR TITLE
Adding release instruction and setting current version to dev

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+To release a new version of qtawesome on PyPI:
+
+Update _version.py (set release version, remove 'dev')
+git add and git commit
+python setup.py sdist upload
+python setup.py bdist_wheel upload
+git tag -a vX.X.X -m 'comment'
+Update _version.py (add 'dev' and increment minor)
+git add and git commit
+git push
+git push --tags

--- a/qtawesome/_version.py
+++ b/qtawesome/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 1, 11)
+version_info = (0, 2, 0, 'dev0')
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
@ccordoba12 streamlining release process for qtawesome.

I also added tags for the past versions, from `0.1.5`. I don't think that earlier versions have much interest.