### PR TITLE
Conda recipe: Remove unneeded build dependencies

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-$PYTHON setup.py install
+
+$PYTHON setup.py install --single-version-externally-managed --root=/

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,6 +12,7 @@ build:
 requirements:
   build:
     - python
+    - setuptools
   run:
     - python
     - six

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,12 +12,10 @@ build:
 requirements:
   build:
     - python
-    - six
-    - qtpy
   run:
     - python
-    - qtpy
     - six
+    - qtpy
 
 test:
   imports:


### PR DESCRIPTION
This is a little trick I learned from the Anaconda team: by using

    python setup.py install --single-version-externally-managed --root=/

we avoid `setuptools` to install or look for runtime dependencies for a package when conda is **building** it.

So this avoids using runtime deps as build deps too in our conda recipe, when the only build deps for `qtawesome` are `python` and `setuptools`. 