### PR TITLE
PR: Add validation to raise exception when fonts are empty or corrupt

### DIFF
--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -202,8 +202,10 @@ class IconicFont(QObject):
         with open(os.path.join(directory, charmap_filename), 'r') as codes:
             self.charmap[prefix] = json.load(codes, object_hook=hook)
 
-        md5_hashes = {'fontawesome-webfont.ttf': 'a3de2170e4e9df77161ea5d3f31b2668',
-                      'elusiveicons-webfont.ttf': '207966b04c032d5b873fd595a211582e'}
+        md5_hashes = {'fontawesome-webfont.ttf':
+                        'a3de2170e4e9df77161ea5d3f31b2668',
+                    'elusiveicons-webfont.ttf':
+                        '207966b04c032d5b873fd595a211582e'}
         ttf_hash = md5_hashes.get(ttf_filename, None)
         if ttf_hash is not None:
             hasher = hashlib.md5()

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -225,7 +225,11 @@ class IconicFont(QObject):
         if(loadedFontFamilies):
             self.fontname[prefix] = loadedFontFamilies[0]
         else:
-            raise FontError(u"Font is empty at: '{0}'".format(
+            raise FontError(u"Font at '{0}' appears to be empty. "
+                            "If you are on Windows 10, please read "
+                            "https://support.microsoft.com/en-us/kb/3053676 "
+                            "to know how to prevent Windows from blocking "
+                            "the fonts that come with QtAwesome.".format(
                             os.path.join(directory, ttf_filename)))
 
     def icon(self, *names, **kwargs):

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -202,19 +202,17 @@ class IconicFont(QObject):
         with open(os.path.join(directory, charmap_filename), 'r') as codes:
             self.charmap[prefix] = json.load(codes, object_hook=hook)
 
-        ttf_hash_code = None
-        if ttf_filename == 'fontawesome-webfont.ttf':
-            ttf_hash_code = 'a3de2170e4e9df77161ea5d3f31b2668'
-        elif ttf_filename == 'elusiveicons-webfont.ttf':
-            ttf_hash_code = '207966b04c032d5b873fd595a211582e'
-        if ttf_hash_code != None:
+        md5_hashes = {'fontawesome-webfont.ttf': 'a3de2170e4e9df77161ea5d3f31b2668',
+                      'elusiveicons-webfont.ttf': '207966b04c032d5b873fd595a211582e'}
+        ttf_hash = md5_hashes.get(ttf_filename, None)
+        if ttf_hash is not None:
             hasher = hashlib.md5()
             with open (os.path.join(directory, ttf_filename),
                        'rb') as tff_font:
                 buffer = tff_font.read()
                 hasher.update(buffer)
             ttf_calculated_hash_code = hasher.hexdigest()
-            if ttf_calculated_hash_code != ttf_hash_code:
+            if ttf_calculated_hash_code != ttf_hash:
                 raise FontError(u"Font is corrupt at: '{0}'".format(
                                 os.path.join(directory, ttf_filename)))
 

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -209,8 +209,7 @@ class IconicFont(QObject):
         ttf_hash = md5_hashes.get(ttf_filename, None)
         if ttf_hash is not None:
             hasher = hashlib.md5()
-            with open (os.path.join(directory, ttf_filename),
-                       'rb') as tff_font:
+            with open(os.path.join(directory, ttf_filename), 'rb') as tff_font:
                 buffer = tff_font.read()
                 hasher.update(buffer)
             ttf_calculated_hash_code = hasher.hexdigest()

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -203,9 +203,9 @@ class IconicFont(QObject):
             self.charmap[prefix] = json.load(codes, object_hook=hook)
 
         md5_hashes = {'fontawesome-webfont.ttf':
-                        'a3de2170e4e9df77161ea5d3f31b2668',
-                    'elusiveicons-webfont.ttf':
-                        '207966b04c032d5b873fd595a211582e'}
+                      'a3de2170e4e9df77161ea5d3f31b2668',
+                      'elusiveicons-webfont.ttf':
+                      '207966b04c032d5b873fd595a211582e'}
         ttf_hash = md5_hashes.get(ttf_filename, None)
         if ttf_hash is not None:
             hasher = hashlib.md5()


### PR DESCRIPTION
This is part of an effort to improve the management of errors that cause a Spyder crash when trying to load fonts from the `.ttf` files in the fonts directory and these are corrupt.