### PR TITLE
PR: Add a way to not verify hash of vendorized fonts

### DIFF
--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -26,6 +26,11 @@ from qtpy.QtGui import (QColor, QFont, QFontDatabase, QIcon, QIconEngine,
 from six import unichr
 
 
+# Linux packagers, please set this to True if you want to make qtawesome
+# use system fonts
+SYSTEM_FONTS = False
+
+
 _default_options = {
     'color': QColor(50, 50, 50),
     'color_disabled': QColor(150, 150, 150),
@@ -213,24 +218,25 @@ class IconicFont(QObject):
                             "the fonts that come with QtAwesome.".format(
                             os.path.join(directory, ttf_filename)))
 
-        # Verify that font is not corrupt
         with open(os.path.join(directory, charmap_filename), 'r') as codes:
             self.charmap[prefix] = json.load(codes, object_hook=hook)
 
-        md5_hashes = {'fontawesome-webfont.ttf':
-                      'a3de2170e4e9df77161ea5d3f31b2668',
-                      'elusiveicons-webfont.ttf':
-                      '207966b04c032d5b873fd595a211582e'}
-        ttf_hash = md5_hashes.get(ttf_filename, None)
-        if ttf_hash is not None:
-            hasher = hashlib.md5()
-            with open(os.path.join(directory, ttf_filename), 'rb') as tff_font:
-                buffer = tff_font.read()
-                hasher.update(buffer)
-            ttf_calculated_hash_code = hasher.hexdigest()
-            if ttf_calculated_hash_code != ttf_hash:
-                raise FontError(u"Font is corrupt at: '{0}'".format(
-                                os.path.join(directory, ttf_filename)))
+        # Verify that vendorized fonts are not corrupt
+        if not SYSTEM_FONTS:
+            md5_hashes = {'fontawesome-webfont.ttf':
+                          'a3de2170e4e9df77161ea5d3f31b2668',
+                          'elusiveicons-webfont.ttf':
+                          '207966b04c032d5b873fd595a211582e'}
+            ttf_hash = md5_hashes.get(ttf_filename, None)
+            if ttf_hash is not None:
+                hasher = hashlib.md5()
+                with open(os.path.join(directory, ttf_filename), 'rb') as f:
+                    content = f.read()
+                    hasher.update(content)
+                ttf_calculated_hash_code = hasher.hexdigest()
+                if ttf_calculated_hash_code != ttf_hash:
+                    raise FontError(u"Font is corrupt at: '{0}'".format(
+                                    os.path.join(directory, ttf_filename)))
 
     def icon(self, *names, **kwargs):
         """Return a QIcon object corresponding to the provided icon name."""


### PR DESCRIPTION
Fixes #64.

----

This is needed for Linux packagers that want to use system fonts.