### PR TITLE
PR: Add a QApplication instance before calling load_font -> QFontDatabase

### DIFF
--- a/qtawesome/__init__.py
+++ b/qtawesome/__init__.py
@@ -15,6 +15,9 @@ Font-Awesome and other iconic fonts for PyQt / PySide applications.
    font
    set_defaults
 """
+# Third party imports
+from qtpy import QtWidgets
+app = QtWidgets.QApplication([])
 
 from .iconic_font import IconicFont, set_global_defaults
 from .animation import Pulse, Spin

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -23,10 +23,8 @@ import hashlib
 from qtpy.QtCore import QObject, QPoint, QRect, qRound, Qt
 from qtpy.QtGui import (QColor, QFont, QFontDatabase, QIcon, QIconEngine,
                         QPainter, QPixmap)
+from qtpy import QtWidgets
 from six import unichr
-
-# Spyder imports
-from spyder.utils.qthelpers import qapplication
 
 # Linux packagers, please set this to True if you want to make qtawesome
 # use system fonts
@@ -176,7 +174,7 @@ class IconicFont(QObject):
         self.painters = {}
         self.fontname = {}
         self.charmap = {}
-        qapplication()
+        app = QtWidgets.QApplication([])
         for fargs in args:
             self.load_font(*fargs)
 

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -23,8 +23,8 @@ import hashlib
 from qtpy.QtCore import QObject, QPoint, QRect, qRound, Qt
 from qtpy.QtGui import (QColor, QFont, QFontDatabase, QIcon, QIconEngine,
                         QPainter, QPixmap)
-from qtpy import QtWidgets
 from six import unichr
+
 
 # Linux packagers, please set this to True if you want to make qtawesome
 # use system fonts
@@ -174,7 +174,6 @@ class IconicFont(QObject):
         self.painters = {}
         self.fontname = {}
         self.charmap = {}
-        app = QtWidgets.QApplication([])
         for fargs in args:
             self.load_font(*fargs)
 

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -25,6 +25,8 @@ from qtpy.QtGui import (QColor, QFont, QFontDatabase, QIcon, QIconEngine,
                         QPainter, QPixmap)
 from six import unichr
 
+# Spyder imports
+from spyder.utils.qthelpers import qapplication
 
 # Linux packagers, please set this to True if you want to make qtawesome
 # use system fonts
@@ -174,6 +176,7 @@ class IconicFont(QObject):
         self.painters = {}
         self.fontname = {}
         self.charmap = {}
+        qapplication()
         for fargs in args:
             self.load_font(*fargs)
 


### PR DESCRIPTION
This fixes the issue [#4014](https://github.com/spyder-ide/spyder/issues/4014) in Spyder. A segfault issue caused for the use of QFontDatabase without a QApplication instance when listing the `modules` with the `help()` command of the Python console.

Edit to include a reference to the issue in Spyder.