### PR TITLE
PR: Replace qRound (missing in PySide2) with round

### DIFF
--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -21,7 +21,7 @@ import hashlib
 import warnings
 
 # Third party imports
-from qtpy.QtCore import QObject, QPoint, QRect, qRound, Qt
+from qtpy.QtCore import QObject, QPoint, QRect, Qt
 from qtpy.QtGui import (QColor, QFont, QFontDatabase, QIcon, QIconEngine,
                         QPainter, QPixmap)
 from qtpy.QtWidgets import QApplication
@@ -109,7 +109,7 @@ class CharIconPainter:
         # The reason why the glyph size is smaller than the icon size is to
         # account for font bearing.
 
-        draw_size = 0.875 * qRound(rect.height() * options['scale_factor'])
+        draw_size = 0.875 * round(rect.height() * options['scale_factor'])
         prefix = options['prefix']
 
         # Animation setup hook


### PR DESCRIPTION
PySide2 misses que qRound method. It can be simply replaced by the Python built-in round.