### PR TITLE
Fix AppVeyor builds by removing Py3.5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,15 +16,11 @@ environment:
                         # to the matrix section.
   matrix:
     # PyQt5
-    - PYTHON_VERSION: "3.5"
-      CONDA_DEPENDENCIES: "qt=5.* pyqt=5.*"
     - PYTHON_VERSION: "3.4"
       CONDA_DEPENDENCIES: "qt=5.* pyqt=5.*"
     - PYTHON_VERSION: "2.7"
       CONDA_DEPENDENCIES: "qt=5.* pyqt=5.*"
     # PyQt4
-    - PYTHON_VERSION: "3.5"
-      CONDA_DEPENDENCIES: "qt=4.* pyqt=4.*"
     - PYTHON_VERSION: "3.4"
       CONDA_DEPENDENCIES: "qt=4.* pyqt=4.*"
     - PYTHON_VERSION: "2.7"


### PR DESCRIPTION
As mentioned in PR #86, `setup.py` says:
```
        # Supported Python versions
        'Programming Language :: Python :: 2',
        'Programming Language :: Python :: 2.6',
        'Programming Language :: Python :: 2.7',
        'Programming Language :: Python :: 3',
        'Programming Language :: Python :: 3.2',
        'Programming Language :: Python :: 3.3',
        'Programming Language :: Python :: 3.4',]
```
No Python 3.5 there... so I'm removing it from `appveyor.yml` to fix the AppVeyor builds. ¯\\\_(ツ)\_/¯

Sound good?