### PR TITLE
PR: Fix bad package dependency in docs/environment.yml

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,6 +4,6 @@ channels:
  - https://conda.anaconda.org/spyder-ide
 
 dependencies:
-- pyqt5
+- pyqt
 - qtpy
 - six


### PR DESCRIPTION
Should fix the ReadTheDocs builds that have been broken for a while:
https://readthedocs.org/projects/qtawesome/builds/8159001/
