### PR TITLE
Provide CharIconEngine.isNull() returning False

### DIFF
--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -162,6 +162,9 @@ class CharIconEngine(QIconEngine):
         self.paint(QPainter(pm), QRect(QPoint(0, 0), size), mode, state)
         return pm
 
+    def isNull(self):
+        return False
+
 
 class IconicFont(QObject):
 


### PR DESCRIPTION
The default implementation of `QIconEngine.isNull()` returns True, which means other methods are never even attempted in PyQT 5.12.

Fixes #113 