### PR TITLE
PR: Add rotated, hflip, and vflip options

### DIFF
--- a/example.py
+++ b/example.py
@@ -26,6 +26,17 @@ class AwesomeExample(QtWidgets.QDialog):
         mdi_icon = qta.icon('mdi.access-point-network')
         mdi_button = QtWidgets.QPushButton(mdi_icon, 'Material Icons!')
 
+        # rotated
+        rot_icon = qta.icon('mdi.access-point-network', rotated=45)
+        rot_button = QtWidgets.QPushButton(rot_icon, 'Rotated Icons!')
+
+        # hflip
+        hflip_icon = qta.icon('mdi.account-alert', hflip=True)
+        hflip_button = QtWidgets.QPushButton(hflip_icon, 'Horizontally Flipped Icons!')
+
+        # vflip
+        vflip_icon = qta.icon('mdi.account-alert', vflip=True)
+        vflip_button = QtWidgets.QPushButton(vflip_icon, 'Vertically Flipped Icons!')
         # Styling
         styling_icon = qta.icon('fa5s.music',
                                 active='fa5s.balance-scale',
@@ -87,6 +98,7 @@ class AwesomeExample(QtWidgets.QDialog):
         # Layout
         vbox = QtWidgets.QVBoxLayout()
         widgets = [fa_button, elusive_button, mdi_button, music_button,
+                   rot_button, hflip_button, vflip_button,
                    toggle_button, stack_button, saveall_button, spin_button,
                    pulse_button, stack_spin_button, label]
 

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -23,7 +23,7 @@ import warnings
 # Third party imports
 from qtpy.QtCore import QObject, QPoint, QRect, Qt
 from qtpy.QtGui import (QColor, QFont, QFontDatabase, QIcon, QIconEngine,
-                        QPainter, QPixmap)
+                        QPainter, QPixmap, QTransform)
 from qtpy.QtWidgets import QApplication
 from six import unichr
 
@@ -61,7 +61,7 @@ def set_global_defaults(**kwargs):
         'color_active', 'color_selected', 'color_disabled',
         'color_on_selected', 'color_on_active', 'color_on_disabled',
         'color_off_selected', 'color_off_active', 'color_off_disabled',
-        'animation', 'offset', 'scale_factor',
+        'animation', 'offset', 'scale_factor', 'rotated', 'hflip', 'vflip'
         ]
 
     for kw in kwargs:
@@ -132,6 +132,30 @@ class CharIconPainter:
             rect.translate(options['offset'][0] * rect.width(),
                            options['offset'][1] * rect.height())
 
+        if 'rotated' in options:
+            x_center = rect.width() * 0.5
+            y_center = rect.height() * 0.5
+            painter.translate(x_center, y_center)
+            painter.rotate(options['rotated'])
+            painter.translate(-x_center, -y_center)
+
+        if 'hflip' in options and options['hflip'] == True:
+            x_center = rect.width() * 0.5
+            y_center = rect.height() * 0.5
+            painter.translate(x_center, y_center)
+            transfrom = QTransform()
+            transfrom.scale(-1, 1)
+            painter.setTransform(transfrom, True)
+            painter.translate(-x_center, -y_center)
+
+        elif 'vflip' in options and options['vflip'] == True:
+            x_center = rect.width() * 0.5
+            y_center = rect.height() * 0.5
+            painter.translate(x_center, y_center)
+            transfrom = QTransform()
+            transfrom.scale(1,-1)
+            painter.setTransform(transfrom, True)
+            painter.translate(-x_center, -y_center)
         painter.setOpacity(options.get('opacity', 1.0))
 
         painter.drawText(rect, Qt.AlignCenter | Qt.AlignVCenter, char)

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -132,11 +132,13 @@ class CharIconPainter:
             rect.translate(options['offset'][0] * rect.width(),
                            options['offset'][1] * rect.height())
 
-        if 'rotated' in options:
+        if 'vflip' in options and options['vflip'] == True:
             x_center = rect.width() * 0.5
             y_center = rect.height() * 0.5
             painter.translate(x_center, y_center)
-            painter.rotate(options['rotated'])
+            transfrom = QTransform()
+            transfrom.scale(1,-1)
+            painter.setTransform(transfrom, True)
             painter.translate(-x_center, -y_center)
 
         if 'hflip' in options and options['hflip'] == True:
@@ -148,14 +150,13 @@ class CharIconPainter:
             painter.setTransform(transfrom, True)
             painter.translate(-x_center, -y_center)
 
-        elif 'vflip' in options and options['vflip'] == True:
+        if 'rotated' in options:
             x_center = rect.width() * 0.5
             y_center = rect.height() * 0.5
             painter.translate(x_center, y_center)
-            transfrom = QTransform()
-            transfrom.scale(1,-1)
-            painter.setTransform(transfrom, True)
+            painter.rotate(options['rotated'])
             painter.translate(-x_center, -y_center)
+
         painter.setOpacity(options.get('opacity', 1.0))
 
         painter.drawText(rect, Qt.AlignCenter | Qt.AlignVCenter, char)


### PR DESCRIPTION
I attempted to address #112. The added behavior mimic the helper CSS classes detailed on the material design icons usage page (https://cdn.materialdesignicons.com/3.0.39/)

Fixes #112.