### PR TITLE
Do not call python directly in tests

### DIFF
--- a/qtawesome/tests/test_qtawesome.py
+++ b/qtawesome/tests/test_qtawesome.py
@@ -3,6 +3,7 @@ Tests for QtAwesome.
 """
 # Standard library imports
 import subprocess
+import sys
 import collections
 
 # Test Library imports
@@ -14,7 +15,7 @@ from qtawesome.iconic_font import IconicFont
 
 
 def test_segfault_import():
-    output_number = subprocess.call('python -c "import qtawesome '
+    output_number = subprocess.call(sys.executable + ' -c "import qtawesome '
                                     '; qtawesome.icon()"', shell=True)
     assert output_number == 0
 


### PR DESCRIPTION
At least on openSUSE it requires python2 interpreter, but like this it calls the interpreter we are working with.