### PR TITLE
PR: Update release instructions for the 0.x branch

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,11 +6,17 @@ To release a new version of qtawesome on PyPI:
 
 * git clean -xfdi
 
-* Update Changelog with `loghub spyder-ide/qtawesome -zr "qtawesome vX.X.X"`
+* Update Changelog with
 
-* Update _version.py (set release version, remove 'dev')
+      loghub spyder-ide/qtawesome -zr "qtawesome vX.X.X"
+
+* Update `_version.py` (set release version, remove 'dev0')
 
 * git add and git commit with "Release x.x.x"
+
+* Update the most important release packages with
+
+      pip install -U pip setuptools twine wheel
 
 * python setup.py sdist
 
@@ -20,10 +26,16 @@ To release a new version of qtawesome on PyPI:
 
 * git tag -a vX.X.X -m 'Release x.x.x'
 
-* Update _version.py (add 'dev0' and increment minor)
+* Update `_version.py` (add 'dev0' and increment minor)
 
 * git add and git commit with "Back to work"
 
+* git checkout master
+
+* git merge 0.x and git commit with "Merge from 0.x: Release x.x.x"
+
 * git push upstream master
+
+* git push upstream 0.x
 
 * git push upstream --tags


### PR DESCRIPTION
This adds more detailed instructions on how to do a release from the `0.x` branch.

@dalthviz, please review this one and merge if/when you consider it necessary.