### PR TITLE
PR: Perform a font id validation

### DIFF
--- a/qtawesome/__init__.py
+++ b/qtawesome/__init__.py
@@ -17,7 +17,7 @@ Font-Awesome and other iconic fonts for PyQt / PySide applications.
 """
 
 # Third party imports
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets, QtGui
 
 # Local imports
 from ._version import __version__, version_info
@@ -26,6 +26,22 @@ from .iconic_font import IconicFont, set_global_defaults
 
 # Constants
 _resource = { 'iconic': None }
+
+
+def has_valid_font_ids(inst):
+    """Validate instance's font ids are loaded to QFontDatabase.
+
+    It is possible that QFontDatabase was reset or QApplication was recreated
+    in both cases it is possible that font is not available.
+    """
+    # Check stored font ids are still available
+    for font_id in inst.fontid.values():
+        font_families = QtGui.QFontDatabase.applicationFontFamilies(
+            font_id
+        )
+        if not font_families:
+            return False
+    return True
 
 
 def _instance():

--- a/qtawesome/__init__.py
+++ b/qtawesome/__init__.py
@@ -51,6 +51,13 @@ def _instance():
     Functions ``icon``, ``load_font``, ``charmap``, ``font`` and
     ``set_defaults`` all rebind to methods of the singleton instance of IconicFont.
     """
+    if (
+        _resource['iconic'] is not None
+        and not has_valid_font_ids(_resource['iconic'])
+    ):
+        # Reset cached instance
+        _resource['iconic'] = None
+
     if _resource['iconic'] is None:
         _resource['iconic'] = IconicFont(
             ('fa',

--- a/qtawesome/__init__.py
+++ b/qtawesome/__init__.py
@@ -35,7 +35,7 @@ def has_valid_font_ids(inst):
     in both cases it is possible that font is not available.
     """
     # Check stored font ids are still available
-    for font_id in inst.fontid.values():
+    for font_id in inst.fontids.values():
         font_families = QtGui.QFontDatabase.applicationFontFamilies(
             font_id
         )

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -207,6 +207,7 @@ class IconicFont(QObject):
         self.painter = CharIconPainter()
         self.painters = {}
         self.fontname = {}
+        self.fontids = {}
         self.charmap = {}
         self.icon_cache = {}
         for fargs in args:
@@ -257,6 +258,7 @@ class IconicFont(QObject):
             loadedFontFamilies = QFontDatabase.applicationFontFamilies(id_)
 
             if loadedFontFamilies:
+                self.fontids[prefix] = id_
                 self.fontname[prefix] = loadedFontFamilies[0]
             else:
                 raise FontError(u"Font at '{0}' appears to be empty. "


### PR DESCRIPTION
## Issue
- singleton instance does not check if it's fonts are still available in `QFontDatabase`

## Changes
- `IconicFont` object also store loaded font ids
- added validation callback when `_instance()` is called to check if font ids are still in `QFontDatabase`