### PR TITLE
Kill QTimer when spinner parent is destroyed

### DIFF
--- a/qtawesome/animation.py
+++ b/qtawesome/animation.py
@@ -7,6 +7,7 @@ class Spin:
         self.parent_widget = parent_widget
         self.interval, self.step = interval, step
         self.info = {}
+        self.timer = None
 
     def _update(self):
         if self.parent_widget in self.info:
@@ -22,17 +23,21 @@ class Spin:
     def setup(self, icon_painter, painter, rect):
 
         if self.parent_widget not in self.info:
-            timer = QTimer()
-            timer.timeout.connect(self._update)
-            self.info[self.parent_widget] = [timer, 0, self.step]
-            timer.start(self.interval)
+            self.timer = QTimer()
+            self.timer.timeout.connect(self._update)
+            self.info[self.parent_widget] = [self.timer, 0, self.step]
+            self.timer.start(self.interval)
+            self.parent_widget.destroyed.connect(self.__del__)
         else:
-            timer, angle, self.step = self.info[self.parent_widget]
+            self.timer, angle, self.step = self.info[self.parent_widget]
             x_center = rect.width() * 0.5
             y_center = rect.height() * 0.5
             painter.translate(x_center, y_center)
             painter.rotate(angle)
             painter.translate(-x_center, -y_center)
+
+    def __del__(self):
+        self.timer.stop()
 
 
 class Pulse(Spin):


### PR DESCRIPTION
Hi,

First of all thanks for an excellent library!
I run into issues with the spinner: I deleted the parent element, but the QTimer seemed to be left calling Spin.update at regular intervals. This caused runtime errors (RuntimeError: Internal C++ object (IconWidget) already deleted.).

Fixed by listening to parents deleted signal, and stopping the timer upon this.

Please let me know if any more tests are required.