### PR TITLE
PR: Change access of constants to scoped enum style for PyQt6

### DIFF
--- a/qtawesome/icon_browser.py
+++ b/qtawesome/icon_browser.py
@@ -45,17 +45,17 @@ class IconBrowser(QtWidgets.QMainWindow):
 
         self._proxyModel = QtCore.QSortFilterProxyModel()
         self._proxyModel.setSourceModel(model)
-        self._proxyModel.setFilterCaseSensitivity(QtCore.Qt.CaseInsensitive)
+        self._proxyModel.setFilterCaseSensitivity(QtCore.Qt.CaseSensitivity.CaseInsensitive)
 
         self._listView = IconListView(self)
         self._listView.setUniformItemSizes(True)
-        self._listView.setViewMode(QtWidgets.QListView.IconMode)
+        self._listView.setViewMode(QtWidgets.QListView.ViewMode.IconMode)
         self._listView.setModel(self._proxyModel)
-        self._listView.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self._listView.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self._listView.doubleClicked.connect(self._copyIconText)
 
         self._lineEdit = QtWidgets.QLineEdit(self)
-        self._lineEdit.setAlignment(QtCore.Qt.AlignCenter)
+        self._lineEdit.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         self._lineEdit.textChanged.connect(self._triggerDelayedUpdate)
         self._lineEdit.returnPressed.connect(self._triggerImmediateUpdate)
 
@@ -90,7 +90,7 @@ class IconBrowser(QtWidgets.QMainWindow):
         self.setCentralWidget(frame)
 
         QtWidgets.QShortcut(
-            QtGui.QKeySequence(QtCore.Qt.Key_Return),
+            QtGui.QKeySequence(QtCore.Qt.Key.Key_Return),
             self,
             self._copyIconText,
         )
@@ -180,7 +180,7 @@ class IconListView(QtWidgets.QListView):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
 
     def resizeEvent(self, event):
         """
@@ -211,7 +211,7 @@ class IconModel(QtCore.QStringListModel):
         super().__init__()
 
     def flags(self, index):
-        return QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
+        return QtCore.Qt.ItemFlag.ItemIsEnabled | QtCore.Qt.ItemFlag.ItemIsSelectable
 
     def data(self, index, role):
         """
@@ -226,8 +226,8 @@ class IconModel(QtCore.QStringListModel):
         -------
         Any
         """
-        if role == QtCore.Qt.DecorationRole:
-            iconString = self.data(index, role=QtCore.Qt.DisplayRole)
+        if role == QtCore.Qt.ItemDataRole.DecorationRole:
+            iconString = self.data(index, role=QtCore.Qt.ItemDataRole.DisplayRole)
             return qtawesome.icon(iconString)
         return super().data(index, role)
 

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -48,7 +48,7 @@ MD5_HASHES = {
 def text_color():
     try:
         palette = QApplication.instance().palette()
-        return palette.color(QPalette.Active, QPalette.Text)
+        return palette.color(QPalette.ColorGroup.Active, QPalette.ColorRole.Text)
     except AttributeError:
         return QColor(50, 50, 50)
 
@@ -56,7 +56,7 @@ def text_color():
 def text_color_disabled():
     try:
         palette = QApplication.instance().palette()
-        return palette.color(QPalette.Disabled, QPalette.Text)
+        return palette.color(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text)
     except AttributeError:
         return QColor(150, 150, 150)
 
@@ -107,23 +107,23 @@ class CharIconPainter:
         char = options['char']
 
         color_options = {
-            QIcon.On: {
-                QIcon.Normal: (options['color_on'], options['on']),
-                QIcon.Disabled: (options['color_on_disabled'],
+            QIcon.State.On: {
+                QIcon.Mode.Normal: (options['color_on'], options['on']),
+                QIcon.Mode.Disabled: (options['color_on_disabled'],
                                  options['on_disabled']),
-                QIcon.Active: (options['color_on_active'],
+                QIcon.Mode.Active: (options['color_on_active'],
                                options['on_active']),
-                QIcon.Selected: (options['color_on_selected'],
+                QIcon.Mode.Selected: (options['color_on_selected'],
                                  options['on_selected'])
             },
 
-            QIcon.Off: {
-                QIcon.Normal: (options['color_off'], options['off']),
-                QIcon.Disabled: (options['color_off_disabled'],
+            QIcon.State.Off: {
+                QIcon.Mode.Normal: (options['color_off'], options['off']),
+                QIcon.Mode.Disabled: (options['color_off_disabled'],
                                  options['off_disabled']),
-                QIcon.Active: (options['color_off_active'],
+                QIcon.Mode.Active: (options['color_off_active'],
                                options['off_active']),
-                QIcon.Selected: (options['color_off_selected'],
+                QIcon.Mode.Selected: (options['color_off_selected'],
                                  options['off_selected'])
             }
         }
@@ -188,7 +188,7 @@ class CharIconPainter:
 
         painter.setOpacity(options.get('opacity', 1.0))
 
-        painter.drawText(rect, int(Qt.AlignCenter | Qt.AlignVCenter), char)
+        painter.drawText(rect, int(Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter), char)
         painter.restore()
 
 
@@ -212,7 +212,7 @@ class CharIconEngine(QIconEngine):
 
     def pixmap(self, size, mode, state):
         pm = QPixmap(size)
-        pm.fill(Qt.transparent)
+        pm.fill(Qt.GlobalColor.transparent)
         self.paint(QPainter(pm), QRect(QPoint(0, 0), size), mode, state)
         return pm
 

--- a/qtawesome/styles.py
+++ b/qtawesome/styles.py
@@ -38,35 +38,35 @@ def dark(app):
     dark_palette = QPalette()
 
     # base
-    dark_palette.setColor(QPalette.WindowText, QColor(180, 180, 180))
-    dark_palette.setColor(QPalette.Button, QColor(53, 53, 53))
-    dark_palette.setColor(QPalette.Light, QColor(180, 180, 180))
-    dark_palette.setColor(QPalette.Midlight, QColor(90, 90, 90))
-    dark_palette.setColor(QPalette.Dark, QColor(35, 35, 35))
-    dark_palette.setColor(QPalette.Text, QColor(180, 180, 180))
-    dark_palette.setColor(QPalette.BrightText, QColor(180, 180, 180))
-    dark_palette.setColor(QPalette.ButtonText, QColor(180, 180, 180))
-    dark_palette.setColor(QPalette.Base, QColor(42, 42, 42))
-    dark_palette.setColor(QPalette.Window, QColor(53, 53, 53))
-    dark_palette.setColor(QPalette.Shadow, QColor(20, 20, 20))
-    dark_palette.setColor(QPalette.Highlight, QColor(42, 130, 218))
-    dark_palette.setColor(QPalette.HighlightedText, QColor(180, 180, 180))
-    dark_palette.setColor(QPalette.Link, QColor(56, 252, 196))
-    dark_palette.setColor(QPalette.AlternateBase, QColor(66, 66, 66))
-    dark_palette.setColor(QPalette.ToolTipBase, QColor(53, 53, 53))
-    dark_palette.setColor(QPalette.ToolTipText, QColor(180, 180, 180))
-    dark_palette.setColor(QPalette.LinkVisited, QColor(80, 80, 80))
+    dark_palette.setColor(QPalette.ColorRole.WindowText, QColor(180, 180, 180))
+    dark_palette.setColor(QPalette.ColorRole.Button, QColor(53, 53, 53))
+    dark_palette.setColor(QPalette.ColorRole.Light, QColor(180, 180, 180))
+    dark_palette.setColor(QPalette.ColorRole.Midlight, QColor(90, 90, 90))
+    dark_palette.setColor(QPalette.ColorRole.Dark, QColor(35, 35, 35))
+    dark_palette.setColor(QPalette.ColorRole.Text, QColor(180, 180, 180))
+    dark_palette.setColor(QPalette.ColorRole.BrightText, QColor(180, 180, 180))
+    dark_palette.setColor(QPalette.ColorRole.ButtonText, QColor(180, 180, 180))
+    dark_palette.setColor(QPalette.ColorRole.Base, QColor(42, 42, 42))
+    dark_palette.setColor(QPalette.ColorRole.Window, QColor(53, 53, 53))
+    dark_palette.setColor(QPalette.ColorRole.Shadow, QColor(20, 20, 20))
+    dark_palette.setColor(QPalette.ColorRole.Highlight, QColor(42, 130, 218))
+    dark_palette.setColor(QPalette.ColorRole.HighlightedText, QColor(180, 180, 180))
+    dark_palette.setColor(QPalette.ColorRole.Link, QColor(56, 252, 196))
+    dark_palette.setColor(QPalette.ColorRole.AlternateBase, QColor(66, 66, 66))
+    dark_palette.setColor(QPalette.ColorRole.ToolTipBase, QColor(53, 53, 53))
+    dark_palette.setColor(QPalette.ColorRole.ToolTipText, QColor(180, 180, 180))
+    dark_palette.setColor(QPalette.ColorRole.LinkVisited, QColor(80, 80, 80))
 
     # disabled
-    dark_palette.setColor(QPalette.Disabled, QPalette.WindowText,
+    dark_palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText,
                          QColor(127, 127, 127))
-    dark_palette.setColor(QPalette.Disabled, QPalette.Text,
+    dark_palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text,
                          QColor(127, 127, 127))
-    dark_palette.setColor(QPalette.Disabled, QPalette.ButtonText,
+    dark_palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.ButtonText,
                          QColor(127, 127, 127))
-    dark_palette.setColor(QPalette.Disabled, QPalette.Highlight,
+    dark_palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Highlight,
                          QColor(80, 80, 80))
-    dark_palette.setColor(QPalette.Disabled, QPalette.HighlightedText,
+    dark_palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.HighlightedText,
                          QColor(127, 127, 127))
 
     app.style().unpolish(app)
@@ -86,35 +86,35 @@ def light(app):
     light_palette = QPalette()
 
     # base
-    light_palette.setColor(QPalette.WindowText, QColor(0, 0, 0))
-    light_palette.setColor(QPalette.Button, QColor(240, 240, 240))
-    light_palette.setColor(QPalette.Light, QColor(180, 180, 180))
-    light_palette.setColor(QPalette.Midlight, QColor(200, 200, 200))
-    light_palette.setColor(QPalette.Dark, QColor(225, 225, 225))
-    light_palette.setColor(QPalette.Text, QColor(0, 0, 0))
-    light_palette.setColor(QPalette.BrightText, QColor(0, 0, 0))
-    light_palette.setColor(QPalette.ButtonText, QColor(0, 0, 0))
-    light_palette.setColor(QPalette.Base, QColor(237, 237, 237))
-    light_palette.setColor(QPalette.Window, QColor(240, 240, 240))
-    light_palette.setColor(QPalette.Shadow, QColor(20, 20, 20))
-    light_palette.setColor(QPalette.Highlight, QColor(76, 163, 224))
-    light_palette.setColor(QPalette.HighlightedText, QColor(0, 0, 0))
-    light_palette.setColor(QPalette.Link, QColor(0, 162, 232))
-    light_palette.setColor(QPalette.AlternateBase, QColor(225, 225, 225))
-    light_palette.setColor(QPalette.ToolTipBase, QColor(240, 240, 240))
-    light_palette.setColor(QPalette.ToolTipText, QColor(0, 0, 0))
-    light_palette.setColor(QPalette.LinkVisited, QColor(222, 222, 222))
+    light_palette.setColor(QPalette.ColorRole.WindowText, QColor(0, 0, 0))
+    light_palette.setColor(QPalette.ColorRole.Button, QColor(240, 240, 240))
+    light_palette.setColor(QPalette.ColorRole.Light, QColor(180, 180, 180))
+    light_palette.setColor(QPalette.ColorRole.Midlight, QColor(200, 200, 200))
+    light_palette.setColor(QPalette.ColorRole.Dark, QColor(225, 225, 225))
+    light_palette.setColor(QPalette.ColorRole.Text, QColor(0, 0, 0))
+    light_palette.setColor(QPalette.ColorRole.BrightText, QColor(0, 0, 0))
+    light_palette.setColor(QPalette.ColorRole.ButtonText, QColor(0, 0, 0))
+    light_palette.setColor(QPalette.ColorRole.Base, QColor(237, 237, 237))
+    light_palette.setColor(QPalette.ColorRole.Window, QColor(240, 240, 240))
+    light_palette.setColor(QPalette.ColorRole.Shadow, QColor(20, 20, 20))
+    light_palette.setColor(QPalette.ColorRole.Highlight, QColor(76, 163, 224))
+    light_palette.setColor(QPalette.ColorRole.HighlightedText, QColor(0, 0, 0))
+    light_palette.setColor(QPalette.ColorRole.Link, QColor(0, 162, 232))
+    light_palette.setColor(QPalette.ColorRole.AlternateBase, QColor(225, 225, 225))
+    light_palette.setColor(QPalette.ColorRole.ToolTipBase, QColor(240, 240, 240))
+    light_palette.setColor(QPalette.ColorRole.ToolTipText, QColor(0, 0, 0))
+    light_palette.setColor(QPalette.ColorRole.LinkVisited, QColor(222, 222, 222))
 
     # disabled
-    light_palette.setColor(QPalette.Disabled, QPalette.WindowText,
+    light_palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText,
                           QColor(115, 115, 115))
-    light_palette.setColor(QPalette.Disabled, QPalette.Text,
+    light_palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text,
                           QColor(115, 115, 115))
-    light_palette.setColor(QPalette.Disabled, QPalette.ButtonText,
+    light_palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.ButtonText,
                           QColor(115, 115, 115))
-    light_palette.setColor(QPalette.Disabled, QPalette.Highlight,
+    light_palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Highlight,
                           QColor(190, 190, 190))
-    light_palette.setColor(QPalette.Disabled, QPalette.HighlightedText,
+    light_palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.HighlightedText,
                           QColor(115, 115, 115))
 
     app.style().unpolish(app)

--- a/qtawesome/tests/test_icon_browser.py
+++ b/qtawesome/tests/test_icon_browser.py
@@ -44,16 +44,16 @@ def test_copy(qtbot, browser):
 
     # Enter a search term and press enter
     qtbot.keyClicks(browser._lineEdit, 'google')
-    qtbot.keyPress(browser._lineEdit, QtCore.Qt.Key_Enter)
+    qtbot.keyPress(browser._lineEdit, QtCore.Qt.Key.Key_Enter)
 
     # TODO: Figure out how to do this via a qtbot.mouseClick call
     # Select the first item in the list
     model = browser._listView.model()
     selectionModel = browser._listView.selectionModel()
-    selectionModel.setCurrentIndex(model.index(0, 0), QtCore.QItemSelectionModel.ClearAndSelect)
+    selectionModel.setCurrentIndex(model.index(0, 0), QtCore.QItemSelectionModel.SelectionFlag.ClearAndSelect)
 
     # Click the copy button
-    qtbot.mouseClick(browser._copyButton, QtCore.Qt.LeftButton)
+    qtbot.mouseClick(browser._copyButton, QtCore.Qt.MouseButton.LeftButton)
 
     assert "google" in clipboard.text()
 
@@ -69,7 +69,7 @@ def test_filter(qtbot, browser):
     qtbot.keyClicks(browser._lineEdit, 'google')
 
     # Press Enter to perform the filter
-    qtbot.keyPress(browser._lineEdit, QtCore.Qt.Key_Enter)
+    qtbot.keyPress(browser._lineEdit, QtCore.Qt.Key.Key_Enter)
 
     filteredRowCount = browser._listView.model().rowCount()
     assert initRowCount > filteredRowCount


### PR DESCRIPTION
This PR is for changing access of constants to scoped enum style for PyQt6.
(I used https://github.com/spyder-ide/qtpy/issues/233#issuecomment-820964838 's  tools to change)

As https://github.com/spyder-ide/qtpy/issues/233#issuecomment-946751764 says

> all bindings from 5.12+ (they may be supported in older versions, I just didn't check) supported the scoped enums

in the case of PyQt 5.9.2 provided by the latest conda,
the constants contained in qtawesome can be accessed via scoped enums.

I think this PR can be merged if support of qtawesome is enough with PyQt 5.9.2 or later.

I tested scoped enums using https://gist.github.com/kumattau/fa9e75b4cea6ec3722d9960f5a3996c9.