### PR TITLE
PR: [qta-browser] display selected icon name, Ctrl+F to search icons and tab stops in order of widget appearance

### DIFF
--- a/qtawesome/icon_browser.py
+++ b/qtawesome/icon_browser.py
@@ -95,6 +95,13 @@ class IconBrowser(QtWidgets.QMainWindow):
 
         self.setCentralWidget(frame)
 
+        self.setTabOrder(self._comboBox, self._lineEdit)
+        self.setTabOrder(self._lineEdit, self._combo_style)
+        self.setTabOrder(self._combo_style, self._listView)
+        self.setTabOrder(self._listView, self._nameField)
+        self.setTabOrder(self._nameField, self._copyButton)
+        self.setTabOrder(self._copyButton, self._comboBox)
+
         QtWidgets.QShortcut(
             QtGui.QKeySequence(QtCore.Qt.Key_Return),
             self,


### PR DESCRIPTION
This PR introduces displaying selected icon name and some small improvements.

I think it is better that the selected icon name is displayed separately because the long icon names in the list view is truncated and users makes a mistake in the icon name.

![Screenshot from 2021-10-29 00-05-21](https://user-images.githubusercontent.com/171798/139283785-7c9db618-ebc2-4ea5-a229-3bf04d525877.png)

In addition, the following improvements have been added.

* Ctrl+F shortcut key to search icons
* Set tab stops in order of widget appearance

