### PR TITLE
PR: Change to "Ctrl+F" because PyQt6 doesn't support Modifier + Key

### DIFF
--- a/qtawesome/icon_browser.py
+++ b/qtawesome/icon_browser.py
@@ -108,7 +108,7 @@ class IconBrowser(QtWidgets.QMainWindow):
             self._copyIconText,
         )
         QtWidgets.QShortcut(
-            QtGui.QKeySequence(QtCore.Qt.CTRL + QtCore.Qt.Key_F),
+            QtGui.QKeySequence("Ctrl+F"),
             self,
             self._lineEdit.setFocus,
         )


### PR DESCRIPTION
Hi,

This PR is for changing to "Ctrl+F" because PyQt6 doesn't support Modifier + Key.

With PyQt6,  `QtGui.QKeySequence(QtCore.Qt.CTRL + QtCore.Qt.Key_F)` in qtabrowser gives the following error:

```
  File "/home/qtawesome/qtawesome/icon_browser.py", line 111, in __init__
    QtGui.QKeySequence(QtCore.Qt.CTRL + QtCore.Qt.Key_F),
TypeError: unsupported operand type(s) for +: 'Modifier' and 'Key'
```

I tested qtabrowser on the following PyQt6 version.

```
PyQt6                      6.2.0
PyQt6-Qt6                  6.2.0
PyQt6-sip                  13.1.0
```

