### PR TITLE
PR: Try calling newer Qt methods first before falling back to deprecated/removed ones

### DIFF
--- a/qtawesome/icon_browser.py
+++ b/qtawesome/icon_browser.py
@@ -121,12 +121,12 @@ class IconBrowser(QtWidgets.QMainWindow):
         # Instead, QGuiApplication.screenAt(QPoint) is supported
         # in Qt 5.10 or later.
         try:
+            screen = QtGui.QGuiApplication.screenAt(QtGui.QCursor.pos())
+            centerPoint = screen.geometry().center()
+        except AttributeError:
             desktop = QtWidgets.QApplication.desktop()
             screen = desktop.screenNumber(desktop.cursor().pos())
             centerPoint = desktop.screenGeometry(screen).center()
-        except AttributeError:
-            screen = QtGui.QGuiApplication.screenAt(QtGui.QCursor.pos())
-            centerPoint = screen.geometry().center()
 
         geo.moveCenter(centerPoint)
         self.setGeometry(geo)
@@ -159,9 +159,9 @@ class IconBrowser(QtWidgets.QMainWindow):
         # Instead, QSortFilterProxyModel.setFilterRegularExpression is
         # supported in Qt 5.12 or later.
         try:
-            self._proxyModel.setFilterRegExp(reString)
-        except AttributeError:
             self._proxyModel.setFilterRegularExpression(reString)
+        except AttributeError:
+            self._proxyModel.setFilterRegExp(reString)
 
     def _triggerDelayedUpdate(self):
         """


### PR DESCRIPTION
Hi,

This PR makes new APIs priority use than removed or deprecated APIs
to solves the following DeprecationWarnings of qtabrowser with QT_API=pyside2 or QT_API=pyside6.

QT_API=pyside2
```
qtawesome/icon_browser.py:125: DeprecationWarning: QDesktopWidget.screenNumber(const QPoint & arg__1) const is deprecated
  screen = desktop.screenNumber(desktop.cursor().pos())
qtawesome/qtawesome/icon_browser.py:126: DeprecationWarning: QDesktopWidget.screenGeometry(int screen) const is deprecated
  centerPoint = desktop.screenGeometry(screen).center()
```

QT_API=pyside6
```
qtawesome/icon_browser.py:273: DeprecationWarning: 'exec_' will be removed in the future. Use 'exec' instead.
  sys.exit(app.exec_())
```

* exec_ function is handled as discussed in https://github.com/spyder-ide/qtpy/issues/286
* Additionally, new set Filter Regular Expression is priority used than removed setFilterRegExp considering the possibility that PySide2/PyQt5 will report DeprecationWarning in the future.

I tested that this PR with the current master branch of QtPy (https://github.com/spyder-ide/qtpy/commit/53ce7b00f6cd90eb45e2b78bed953671841d4899) reports no DeprecationWarning on the following environments.

```
PySide2                    5.15.2
PySide6                    6.2.1

PyQt5                      5.15.6
PyQt5-Qt5                  5.15.2
PyQt5-sip                  12.9.0
PyQt5-stubs                5.15.2.0

PyQt6                      6.2.0
PyQt6-Qt6                  6.2.0
PyQt6-sip                  13.1.0

pyqt                      5.9.2            py36h05f1152_2
qt                        5.9.7                h5867ecd_1
sip                       4.19.8           py36hf484d3e_0
```
