### PR TITLE
PR: Preserves timestamp, bboxes, and table order for faithful to original and reproducible font updating

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -29,7 +29,7 @@ def rename_font(font_path, font_name):
     Font renaming code originally from:
     https://github.com/chrissimpkins/fontname.py/blob/master/fontname.py
     """
-    tt = ttLib.TTFont(font_path)
+    tt = ttLib.TTFont(font_path, recalcBBoxes=False, recalcTimestamp=False)
     namerecord_list = tt["name"].names
     variant = ""
 
@@ -68,7 +68,7 @@ def rename_font(font_path, font_name):
 
     # write changes to the font file
     try:
-        tt.save(font_path)
+        tt.save(font_path, reorderTables=False)
     except:
         raise RuntimeError(
             f"ERROR: unable to write new name to OpenType tables for: {font_path}")


### PR DESCRIPTION
This PR resolves the following in https://github.com/spyder-ide/qtawesome/issues/189#issuecomment-988809501

>> Since the timestamp when the family is changed is embedded, the font checksum changes every time the command is executed, which is to be expected.
>
> * implement reproducing processing for changing family

By recalcTimestamp=False, "modified" timestamp field is preserved and same processing to change family returns same binary.
Also, recalcBBoxes=False and reorderTables=False are added to suppress processing that may change the table and content of font.