### PR TITLE
PR: Fix unexpected corruption check except for bundled fonts

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -41,7 +41,7 @@ To update _Material Design Icons 6.x_, you must:
 - download ttf from <https://raw.githubusercontent.com/Templarian/MaterialDesign-Webfont/master/fonts/materialdesignicons-webfont.ttf>
 - regenerate the json charmap with the `materialdesignicons.css` file from <https://raw.githubusercontent.com/Templarian/MaterialDesign-Webfont/master/css/materialdesignicons.css>
 
-The following script automatically download the last TTF font, generate the json charmap and display md5 hash of the TTF (to update iconic_font.py)
+The following script automatically download the last TTF font, generate the json charmap and display md5 hash of the TTF (to update \_\_init__.py)
 
 ```Python
 import re
@@ -95,7 +95,7 @@ To update _Phosphor_, you must:
 - download ttf from <https://raw.githubusercontent.com/phosphor-icons/phosphor-icons/master/src/font/phosphor.ttf>
 - regenerate the json charmap with the `phosphor.css` file from <https://raw.githubusercontent.com/phosphor-icons/phosphor-icons/master/src/css/phosphor.css>
 
-The following script automatically download the last TTF font, generate the json charmap and display md5 hash of the TTF (to update iconic_font.py)
+The following script automatically download the last TTF font, generate the json charmap and display md5 hash of the TTF (to update \_\_init__.py)
 
 ```Python
 import re
@@ -148,7 +148,7 @@ To update _Remix Icon_, you must:
 - download ttf from <https://raw.githubusercontent.com/Remix-Design/RemixIcon/master/fonts/remixicon.ttf>
 - regenerate the json charmap with the `remixicon.css` file from <https://raw.githubusercontent.com/Remix-Design/RemixIcon/master/fonts/remixicon.css>
 
-The following script automatically download the last TTF font, generate the json charmap and display md5 hash of the TTF (to update iconic_font.py)
+The following script automatically download the last TTF font, generate the json charmap and display md5 hash of the TTF (to update \_\_init__.py)
 
 ```Python
 import re

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -15,7 +15,6 @@ methods returning instances of ``QIcon``.
 
 # Standard library imports
 from __future__ import print_function
-import hashlib
 import json
 import os
 import warnings
@@ -29,20 +28,6 @@ from qtpy.QtWidgets import QApplication
 # Linux packagers, please set this to True if you want to make qtawesome
 # use system fonts
 SYSTEM_FONTS = False
-
-# MD5 Hashes for font files bundled with qtawesome:
-MD5_HASHES = {
-    'fontawesome4.7-webfont.ttf': 'b06871f281fee6b241d60582ae9369b9',
-    'fontawesome5-regular-webfont.ttf': '808833867034fb67a4a86dd2155e195d',
-    'fontawesome5-solid-webfont.ttf': '139654bb0acaba6b00ae30d5faf3d02f',
-    'fontawesome5-brands-webfont.ttf': '085b1dd8427dbeff10bd55410915a3f6',
-    'elusiveicons-webfont.ttf': '207966b04c032d5b873fd595a211582e',
-    'materialdesignicons5-webfont.ttf': 'b7d40e7ef80c1d4af6d94902af66e524',
-    'materialdesignicons6-webfont.ttf': '9a2f455e7cbce011368aee95d292613b',
-    'phosphor.ttf': '5b8dc57388b2d86243566b996cc3a789',
-    'remixicon.ttf': '888e61f04316f10bddfff7bee10c6dd0',
-    'codicon.ttf': 'ca2f9e22cee3a59156b3eded74d87784',
-}
 
 
 def text_color():
@@ -302,20 +287,6 @@ class IconicFont(QObject):
 
             with open(os.path.join(directory, charmap_filename), 'r') as codes:
                 self.charmap[prefix] = json.load(codes, object_hook=hook)
-
-            # Verify that vendorized fonts are not corrupt
-            if not SYSTEM_FONTS:
-                ttf_hash = MD5_HASHES.get(ttf_filename, None)
-                if ttf_hash is not None:
-                    hasher = hashlib.md5()
-                    with open(os.path.join(directory, ttf_filename),
-                              'rb') as f:
-                        content = f.read()
-                        hasher.update(content)
-                    ttf_calculated_hash_code = hasher.hexdigest()
-                    if ttf_calculated_hash_code != ttf_hash:
-                        raise FontError(u"Font is corrupt at: '{0}'".format(
-                                        os.path.join(directory, ttf_filename)))
 
     def icon(self, *names, **kwargs):
         """Return a QIcon object corresponding to the provided icon name."""

--- a/setupbase.py
+++ b/setupbase.py
@@ -21,7 +21,7 @@ import distutils.cmd
 import distutils.log
 
 HERE = os.path.abspath(os.path.dirname(__file__))
-ICONIC_FONT_PY_PATH = os.path.join(HERE, 'qtawesome', 'iconic_font.py')
+INIT_PY_PATH = os.path.join(HERE, 'qtawesome', '__init__.py')
 
 
 def rename_font(font_path, font_name):
@@ -209,11 +209,11 @@ class UpdateFA5Command(distutils.cmd.Command):
             # Store hashes for later:
             hashes[style] = hashlib.md5(data).hexdigest()
 
-        # Now it's time to patch "iconic_font.py":
-        iconic_path = ICONIC_FONT_PY_PATH
-        self.__print('Patching new MD5 hashes in: %s' % iconic_path)
-        with open(iconic_path, 'r') as iconic_file:
-            contents = iconic_file.read()
+        # Now it's time to patch "__init__.py":
+        init_path = INIT_PY_PATH
+        self.__print('Patching new MD5 hashes in: %s' % init_path)
+        with open(init_path, 'r') as init_file:
+            contents = init_file.read()
         # We read it in full, then use regex substitution:
         for style, md5 in hashes.items():
             self.__print('New "%s" hash is: %s' % (style, md5))
@@ -221,9 +221,9 @@ class UpdateFA5Command(distutils.cmd.Command):
             subst = r"\g<1>'" + md5 + "'"
             contents = re.sub(regex, subst, contents, 1)
         # and finally overwrite with the modified file:
-        self.__print('Dumping updated file: %s' % iconic_path)
-        with open(iconic_path, 'w') as iconic_file:
-            iconic_file.write(contents)
+        self.__print('Dumping updated file: %s' % init_path)
+        with open(init_path, 'w') as init_file:
+            init_file.write(contents)
 
         self.__print(
             '\nFinished!\n'
@@ -295,16 +295,16 @@ class UpdateCodiconCommand(distutils.cmd.Command):
             md5 = hashlib.md5(data).hexdigest()
             self.__print('New hash is: %s' % md5)
 
-        # Now it's time to patch "iconic_font.py":
-        self.__print('Patching new MD5 hashes in: %s' % ICONIC_FONT_PY_PATH)
-        with open(ICONIC_FONT_PY_PATH, 'r') as iconic_file:
-            contents = iconic_file.read()
+        # Now it's time to patch "__init__.py":
+        self.__print('Patching new MD5 hashes in: %s' % INIT_PY_PATH)
+        with open(INIT_PY_PATH, 'r') as init_file:
+            contents = init_file.read()
         regex = r"('codicon.ttf':\s+)'(\w+)'"
         subst = r"\g<1>'" + md5 + "'"
         contents = re.sub(regex, subst, contents, 1)
-        self.__print('Dumping updated file: %s' % ICONIC_FONT_PY_PATH)
-        with open(ICONIC_FONT_PY_PATH, 'w') as iconic_file:
-            iconic_file.write(contents)
+        self.__print('Dumping updated file: %s' % INIT_PY_PATH)
+        with open(INIT_PY_PATH, 'w') as init_file:
+            init_file.write(contents)
 
         self.__print(
             '\nFinished!\n'


### PR DESCRIPTION
Fixes #196

```SYSTEM_FONTS``` has been removed in iconic_fonts.py because it is no longer needed.

I moved ```MD5_HASHES``` to \_\_init__.py and defined ```BUNDLED_FONTS``` in \_\_init__.py,
but I don't know "_" (underscore) should be prefixed in these variables  as internal use.