### PR TITLE
PR: Update `load_font` documentation

### DIFF
--- a/qtawesome/__init__.py
+++ b/qtawesome/__init__.py
@@ -192,7 +192,8 @@ def load_font(prefix, ttf_filename, charmap_filename, directory=None):
     """
     Loads a font file and the associated charmap.
 
-    If ``directory`` is None, the files will be looked for in ``./fonts/``.
+    If ``directory`` the files will be looked for in the qtawesome ``fonts``
+    directory.
 
     Parameters
     ----------
@@ -203,14 +204,31 @@ def load_font(prefix, ttf_filename, charmap_filename, directory=None):
     charmap_filename: str
         Character map filename
     directory: str or None, optional
-        Directory for font and charmap files
+        Directory path for font and charmap files
 
     Example
     -------
-    The spyder ide uses qtawesome and uses a custom font for spyder-specific
-    icons::
+    If you want to load a font ``myicon.tff`` with a ``myicon-charmap.json``
+    charmap added to the qtawesome ``fonts`` directory (usually located at
+    ``</path/to/lib/python>/site-packages/qtawesome/fonts/``) you can use::
 
-        qta.load_font('spyder', 'spyder.ttf', 'spyder-charmap.json')
+        qta.load_font(
+            'myicon',
+            'myicon.ttf',
+            'myicon-charmap.json'
+            )
+
+    However, if you want to load a font ``myicon.tff`` with a
+    ``myicon-charmap.json`` charmap located in a specific path outside the
+    qtawesome ``font`` directory like for example ``/path/to/myproject/fonts``
+    you can use::
+
+        qta.load_font(
+            'myicon',
+            'myicon.ttf',
+            'myicon-charmap.json',
+            directory='/path/to/myproject/fonts'
+            )
 
     """
     return _instance().load_font(prefix, ttf_filename, charmap_filename, directory)

--- a/qtawesome/__init__.py
+++ b/qtawesome/__init__.py
@@ -192,8 +192,8 @@ def load_font(prefix, ttf_filename, charmap_filename, directory=None):
     """
     Loads a font file and the associated charmap.
 
-    If ``directory`` the files will be looked for in the qtawesome ``fonts``
-    directory.
+    If ``directory`` is passed, the files will be looked for in the qtawesome
+    ``fonts`` directory.
 
     Parameters
     ----------
@@ -216,7 +216,7 @@ def load_font(prefix, ttf_filename, charmap_filename, directory=None):
             'myicon',
             'myicon.ttf',
             'myicon-charmap.json'
-            )
+        )
 
     However, if you want to load a font ``myicon.tff`` with a
     ``myicon-charmap.json`` charmap located in a specific path outside the
@@ -228,7 +228,7 @@ def load_font(prefix, ttf_filename, charmap_filename, directory=None):
             'myicon.ttf',
             'myicon-charmap.json',
             directory='/path/to/myproject/fonts'
-            )
+        )
 
     """
     return _instance().load_font(prefix, ttf_filename, charmap_filename, directory)

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -232,7 +232,8 @@ class IconicFont(QObject):
             - The ttf font filename,
             - The json charmap filename,
             - Optionally, the directory containing these files. When not
-              provided, the files will be looked for in ``./fonts/``.
+              provided, the files will be looked for in the QtAwesome ``fonts``
+              directory.
         """
         super().__init__()
         self.painter = CharIconPainter()
@@ -247,7 +248,8 @@ class IconicFont(QObject):
     def load_font(self, prefix, ttf_filename, charmap_filename, directory=None):
         """Loads a font file and the associated charmap.
 
-        If ``directory`` is None, the files will be looked for in ``./fonts/``.
+        If ``directory`` is None, the files will be looked for in
+        the qtawesome ``fonts`` directory.
 
         Parameters
         ----------
@@ -258,7 +260,7 @@ class IconicFont(QObject):
         charmap_filename: str
             Charmap filename
         directory: str or None, optional
-            Directory for font and charmap files
+            Directory path for font and charmap files
         """
 
         def hook(obj):


### PR DESCRIPTION
Add examples and update the description according to the actually implemented `directory` kwarg handling

Fixes #195 

Also, jus in case, I added the `readthedocs` preview to the checks. So to check the changes done in the docs you can go to: https://qtawesomedocs--198.org.readthedocs.build/en/198/ (or check the `details` link in the `readthedocs` check) 