### PR TITLE
PR: Use QRawFont and draw PainterPath of Glyph for animation to prevent tremulous spinning icons

### DIFF
--- a/example.py
+++ b/example.py
@@ -114,6 +114,14 @@ class AwesomeExample(QtWidgets.QDialog):
                                     {'scale_factor': 0.8}])
         saveall_button = QtWidgets.QPushButton(saveall, 'Stack, offset')
 
+        # Stack and offset icons, draw path
+        saveall_path = qta.icon('fa5.save', 'fa5.save',
+                           options=[{'scale_factor': 0.8,
+                                     'offset': (0.2, 0.2),
+                                     'color': 'gray', 'draw': 'path'},
+                                    {'scale_factor': 0.8, 'draw': 'path'}])
+        saveall_button_path = QtWidgets.QPushButton(saveall_path, 'Stack, offset, draw path')
+
         # Spin icons
         spin_button = QtWidgets.QPushButton(' Spinning icon')
         spin_icon = qta.icon('fa5s.spinner', color='red',
@@ -167,6 +175,7 @@ class AwesomeExample(QtWidgets.QDialog):
             pulse_button,
             stack_button,
             saveall_button,
+            saveall_button_path,
             stack_spin_button,
         ]
         other_widgets = [

--- a/example.py
+++ b/example.py
@@ -114,6 +114,14 @@ class AwesomeExample(QtWidgets.QDialog):
                                     {'scale_factor': 0.8}])
         saveall_button = QtWidgets.QPushButton(saveall, 'Stack, offset')
 
+        # Stack and offset icons, draw image
+        saveall_image = qta.icon('fa5.save', 'fa5.save',
+                           options=[{'scale_factor': 0.8,
+                                     'offset': (0.2, 0.2),
+                                     'color': 'gray', 'draw': 'image'},
+                                    {'scale_factor': 0.8, 'draw': 'image'}])
+        saveall_button_image = QtWidgets.QPushButton(saveall_image, 'Stack, offset, draw image')
+
         # Stack and offset icons, draw path
         saveall_path = qta.icon('fa5.save', 'fa5.save',
                            options=[{'scale_factor': 0.8,
@@ -175,6 +183,7 @@ class AwesomeExample(QtWidgets.QDialog):
             pulse_button,
             stack_button,
             saveall_button,
+            saveall_button_image,
             saveall_button_path,
             stack_spin_button,
         ]

--- a/example.py
+++ b/example.py
@@ -114,22 +114,6 @@ class AwesomeExample(QtWidgets.QDialog):
                                     {'scale_factor': 0.8}])
         saveall_button = QtWidgets.QPushButton(saveall, 'Stack, offset')
 
-        # Stack and offset icons, draw image
-        saveall_image = qta.icon('fa5.save', 'fa5.save',
-                           options=[{'scale_factor': 0.8,
-                                     'offset': (0.2, 0.2),
-                                     'color': 'gray', 'draw': 'image'},
-                                    {'scale_factor': 0.8, 'draw': 'image'}])
-        saveall_button_image = QtWidgets.QPushButton(saveall_image, 'Stack, offset, draw image')
-
-        # Stack and offset icons, draw path
-        saveall_path = qta.icon('fa5.save', 'fa5.save',
-                           options=[{'scale_factor': 0.8,
-                                     'offset': (0.2, 0.2),
-                                     'color': 'gray', 'draw': 'path'},
-                                    {'scale_factor': 0.8, 'draw': 'path'}])
-        saveall_button_path = QtWidgets.QPushButton(saveall_path, 'Stack, offset, draw path')
-
         # Spin icons
         spin_button = QtWidgets.QPushButton(' Spinning icon')
         spin_icon = qta.icon('fa5s.spinner', color='red',
@@ -183,8 +167,6 @@ class AwesomeExample(QtWidgets.QDialog):
             pulse_button,
             stack_button,
             saveall_button,
-            saveall_button_image,
-            saveall_button_path,
             stack_spin_button,
         ]
         other_widgets = [
@@ -198,20 +180,36 @@ class AwesomeExample(QtWidgets.QDialog):
 
         for idx, w in enumerate(styled_widgets):
             grid.addWidget(w, idx, 1)
-        
+
         for idx, w in enumerate(animated_widgets):
             grid.addWidget(w, idx + len(styled_widgets), 1)
-        
+
         for idx, w in enumerate(other_widgets):
             grid.addWidget(w, idx + len(styled_widgets) + len(animated_widgets), 1)
 
+        title = 'Awesome'
+        args = ' '.join(sys.argv[1:]).strip()
+        if args:
+            title += ' (' + args + ')'
+
         self.setLayout(grid)
-        self.setWindowTitle('Awesome')
+        self.setWindowTitle(title)
         self.setMinimumWidth(520)
         self.show()
 
 
 def main():
+
+    global_defaults = {}
+    for arg in sys.argv[1:]:
+        try:
+            key, val = arg.split('=', maxsplit=1)
+            global_defaults[key] = val
+        except:
+            pass
+    if global_defaults:
+        qta.set_global_defaults(**global_defaults)
+
     app = QtWidgets.QApplication(sys.argv)
 
     # Enable High DPI display with PyQt5

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -224,8 +224,9 @@ class CharIconPainter:
         elif draw == 'path':
             draw_path = True
         else:
-            # Use QPainterPath when animation
-            # to fix tremulous spinning icons #39
+            # Use QPainterPath when setting an animation
+            # to fix tremulous spinning icons.
+            # See #39
             draw_path = animation is not None
 
         if draw_path:
@@ -358,10 +359,10 @@ class IconicFont(QObject):
             with open(os.path.join(directory, ttf_filename), 'rb') as font_data:
                 data = font_data.read()
                 id_ = QFontDatabase.addApplicationFontFromData(data)
-                # QRawFont() requires pixelSize, but it is unknown at this time.
-                # So, first create QRowfont with 2048, which is the size of
-                # almost TrueType fonts and reset actual size after that.
-                # Note: When TrueType fonts, pixelSize can be specified up to 16384.
+                # `QRawFont()` requires a `pixelSize` value, but it is unknown at this point.
+                # To workaround that, first we create a `QRawFont` with 2048 as `pixelSize` 
+                # (usual size for TrueType fonts) and reset to the actual size after that.
+                # Note: For TrueType fonts, `pixelSize` can be specified up to 16384.
                 rawfont = QRawFont(data, 2048)
                 rawfont.setPixelSize(rawfont.unitsPerEm())
             font_data.close()

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -203,7 +203,7 @@ class CharIconPainter:
         if draw not in ('text', 'path', 'glyphrun', 'image'):
             # Use QPainterPath when setting an animation
             # to fix tremulous spinning icons.
-            # See #39
+            # See spyder-ide/qtawesome#39
             draw = 'path' if animation is not None else 'text'
 
         def try_draw_rawfont():

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -246,7 +246,15 @@ class CharIconPainter:
             size = alpha.size()
             image = QImage(size, QImage.Format_RGBA8888)
             image.fill(painter.pen().color())
-            image.setAlphaChannel(alpha)
+            try:
+                image.setAlphaChannel(alpha)
+            except AttributeError:
+                a = alpha.convertToFormat(QImage.Format_Grayscale8)
+                for i in range(size.width()):
+                    for j in range(size.height()):
+                        c = image.pixelColor(i, j)
+                        c.setAlpha(a.pixelColor(i, j).red())
+                        image.setPixelColor(i, j, c)
 
             painter.translate(QRectF(rect).center())
             painter.translate(-size.width() / 2, -size.height() / 2)


### PR DESCRIPTION
Maybe #39 can be fixed using QRawFont and draw PainterPath of Glyph.

Compared to QFont, QRawFont is available without registering to font database,
So this approach has

Pros:
* no tremulous spinning
* no family name collision (font patch is not required)

Cons:
* cannot support color-font (PainterPath of Glyph does not have color)
* cannot support font() API (this requires QFont registered to font database)
* I tests it on ubuntu only. I cannot check this approach works on other platform or not

If qtawesome switches QFont to QRawFont, font patch in the update_font script ( #194 ) may not be needed.

How do you think, @dalthviz  ?

Note: current code is example, so it needs refactoring, optimization, etc.

Edit:

Fixes #39 