### PR TITLE
PR: Disable font hinting to mitigate tremulous spinning to some extent

### DIFF
--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -140,7 +140,12 @@ class CharIconPainter:
         if animation is not None:
             animation.setup(self, painter, rect)
 
-        painter.setFont(iconic.font(prefix, draw_size))
+        font = iconic.font(prefix, draw_size)
+        # Disable font hinting to mitigate tremulous spinning to some extent
+        # See spyder-ide/qtawesome#39
+        if animation is not None:
+            font.setHintingPreference(QFont.PreferNoHinting)
+        painter.setFont(font)
         if 'offset' in options:
             rect = QRect(rect)
             rect.translate(round(options['offset'][0] * rect.width()),


### PR DESCRIPTION
Hi @dalthviz.

This PR is to mitigate #39 to some extent.

As https://github.com/spyder-ide/qtawesome/pull/202#issuecomment-1031631561, the method using QRawFont and QPainterPath does not support all fonts supported by QFont.
So, I think the method is optional.

Even if QFont is used, by disabling font hinting, the tremulous spinning seems to be mitigated to some extent.
So, I think it is better that the font hinting is disabled as default when animation.

left: default (enable) hinting, right: disable hinting
![Animation](https://user-images.githubusercontent.com/171798/156019025-66e01b73-78ac-47bb-af0f-168eba231902.gif)