### PR TITLE
PR: Install bundled fonts for user on Windows and fix Linux CI

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -23,11 +23,11 @@ jobs:
         PYTHON_VERSION: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Install System Packages
         run: |
-          sudo apt-get update
-          sudo apt-get install libegl1-mesa
+          sudo apt-get update --fix-missing
+          sudo apt-get install -qq pyqt5-dev-tools libxcb-xinerama0 xterm --fix-missing
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/qtawesome/iconic_font.py
+++ b/qtawesome/iconic_font.py
@@ -502,7 +502,9 @@ class IconicFont(QObject):
 
         On Windows an attempt to install the fonts per user is done
         to prevent errors with fonts loading.
-        See spyder-ide/qtawesome#167 and spyder-ide/spyder#18642
+
+        See spyder-ide/qtawesome#167 and spyder-ide/spyder#18642 for
+        context.
         """
         fonts_directory = os.path.join(
             os.path.dirname(os.path.realpath(__file__)), 'fonts')
@@ -515,16 +517,19 @@ class IconicFont(QObject):
         user_fonts_dir = os.path.join(
             os.environ['LOCALAPPDATA'], 'Microsoft', 'Windows', 'Fonts')
         os.makedirs(user_fonts_dir, exist_ok=True)
+
         for root, __, files in os.walk(fonts_directory):
             for name in files:
                 src_path = os.path.join(root, name)
                 dst_path = os.path.join(
                     user_fonts_dir,
                     os.path.basename(src_path))
+
                 # Check if font already exists and copy font
                 if os.path.isfile(dst_path):
                     continue
                 shutil.copy(src_path, user_fonts_dir)
+
                 # Further process the font file (`.ttf`)
                 if os.path.splitext(name)[-1] == '.ttf':
                     # Load the font in the current session
@@ -532,9 +537,11 @@ class IconicFont(QObject):
                         os.remove(dst_path)
                         raise WindowsError(
                             'AddFontResource failed to load "%s"' % src_path)
+
                     # Store the fontname/filename in the registry
                     filename = os.path.basename(dst_path)
                     fontname = os.path.splitext(filename)[0]
+
                     # Try to get the font's real name
                     cb = wintypes.DWORD()
                     if gdi32.GetFontResourceInfoW(

--- a/qtawesome/tests/test_qtawesome.py
+++ b/qtawesome/tests/test_qtawesome.py
@@ -2,9 +2,10 @@ r"""
 Tests for QtAwesome.
 """
 # Standard library imports
+import collections
+import os
 import subprocess
 import sys
-import collections
 
 # Test Library imports
 import pytest
@@ -40,6 +41,37 @@ def test_unique_font_family_name(qtbot):
     duplicates = [fontname for fontname, count in
                   collections.Counter(fontnames).items() if count > 1]
     assert not duplicates
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Only meant for Windows")
+def test_bundled_font_installation():
+    """
+    Test that the bundled fonts are being installed on Windows.
+    
+    See spyder-ide/qtawesome#167 and spyder-ide/spyder#18642
+    """
+    qta._instance()
+    fonts_expected = [
+        ("codicon", "codicon.ttf"),
+        ("elusiveicons-webfont", "elusiveicons-webfont.ttf"),
+        ("fontawesome4.7-webfont", "fontawesome4.7-webfont.ttf"),
+        ("fontawesome5-brands-webfont", "fontawesome5-brands-webfont.ttf"),
+        ("fontawesome5-regular-webfont", "fontawesome5-regular-webfont.ttf"),
+        ("fontawesome5-solid-webfont", "fontawesome5-solid-webfont.ttf"),
+        ("materialdesignicons5-webfont", "materialdesignicons5-webfont.ttf"),
+        ("materialdesignicons6-webfont ", "materialdesignicons6-webfont.ttf"),
+        ("phosphor", "phosphor.ttf"),
+        ("remixicon", "remixicon.ttf")
+    ]
+    fonts_command = [
+        "powershell.exe",
+        r'Get-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts"'
+    ]
+    fonts_result = subprocess.run(fonts_command, capture_output=True, check=True, text=True).stdout
+    
+    for font_name, font_filename in fonts_expected:
+        assert font_name in fonts_result
+        assert font_filename in fonts_result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Fix CI for Linux
* Add way to copy and register font files to prevent error when using bundled fonts on Windows with the `prevent untrusted fonts` setting on.

Fixes #167 
Part of spyder-ide/spyder#18642