### PR TITLE
PR: Remove usage of deprecated codecov package and move to GitHub Action variant

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -57,6 +57,7 @@ jobs:
           xvfb-run --auto-servernum python example.py
           xvfb-run --auto-servernum pytest -x -vv --cov=qtawesome --cov-report=term-missing qtawesome
       - name: Upload coverage to Codecov
-        if: matrix.PYTHON_VERSION == '3.8'
-        shell: bash -l {0}
-        run: codecov -t ed8563f8-ec80-484d-83eb-4233d7a083d2
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -55,7 +55,7 @@ jobs:
         shell: bash -l {0}
         run: |
           xvfb-run --auto-servernum python example.py
-          xvfb-run --auto-servernum pytest -x -vv --cov=qtawesome --cov-report=term-missing qtawesome
+          xvfb-run --auto-servernum pytest -x -vv --cov-report xml --cov=qtawesome qtawesome
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -50,7 +50,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python example.py
-          pytest -x -vv --cov=qtawesome --cov-report=term-missing qtawesome
+          pytest -x -vv --cov-report xml --cov=qtawesome qtawesome
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -51,3 +51,8 @@ jobs:
         run: |
           python example.py
           pytest -x -vv --cov=qtawesome --cov-report=term-missing qtawesome
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -50,7 +50,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python example.py
-          pytest -x -vv --cov=qtawesome --cov-report=term-missing qtawesome
+          pytest -x -vv --cov-report xml --cov=qtawesome qtawesome
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -51,3 +51,8 @@ jobs:
         run: |
           python example.py
           pytest -x -vv --cov=qtawesome --cov-report=term-missing qtawesome
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
 [![Github Linux build status](https://github.com/spyder-ide/qtawesome/workflows/Linux%20tests/badge.svg)](https://github.com/spyder-ide/qtawesome/actions)
 [![Github MacOS build status](https://github.com/spyder-ide/qtawesome/workflows/Macos%20tests/badge.svg)](https://github.com/spyder-ide/qtawesome/actions)
 [![Documentation Status](https://readthedocs.org/projects/qtawesome/badge/?version=latest)](https://qtawesome.readthedocs.io/en/latest/?badge=latest)
+[![codecov](https://codecov.io/gh/spyder-ide/qtawesome/branch/master/graph/badge.svg?token=Cylan0teq1)](https://codecov.io/gh/spyder-ide/qtawesome)
 
-*Copyright © 2015–2022 Spyder Project Contributors*
+*Copyright © 2015- Spyder Project Contributors*
 
 
 ## Description

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
 dependencies:
-- codecov
 - pyqt
 - pytest
 - pytest-cov

--- a/requirements/environment_tests_pyqt5.yml
+++ b/requirements/environment_tests_pyqt5.yml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
 dependencies:
-- codecov
 - pyqt>=5.15
 - pytest
 - pytest-cov

--- a/requirements/environment_tests_pyside2.yml
+++ b/requirements/environment_tests_pyside2.yml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
 dependencies:
-- codecov
 - pyside2>=5.15
 - pytest
 - pytest-cov


### PR DESCRIPTION
Using the codecov package can causes CI to fail with `pip` since the `codecov` package was removed from PyPI. The error from CI is the following:

```
ERROR: Could not find a version that satisfies the requirement codecov (from versions: none)
ERROR: No matching distribution found for codecov
```

Example Spyder CI run where this happens: https://github.com/spyder-ide/spyder/actions/runs/4681680400/jobs/8294575413?pr=20421#step:10:420

Remove codecov from requirements and use Codecov GitHub Action instead to upload coverage reports