### PR TITLE
PR: Provide icon size when creating an `IconWidget`

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ spin_icon = qta.icon('mdi.loading', color='red',
 spin_widget.setIcon(spin_icon)
 
 # Simple icon widget
-simple_widget = qta.IconWidget('mdi.web', color='blue')
+simple_widget = qta.IconWidget('mdi.web', color='blue', 
+                               size=QtCore.QSize(16, 16))
 ```
 
 - Screenshot

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -206,14 +206,15 @@ Examples
 
 .. code:: python
 
-   # Spining icon widget
+   # Spinning icon widget
    spin_widget = qta.IconWidget()
    spin_icon = qta.icon('mdi.loading', color='red',
                         animation=qta.Spin(spin_widget))
    spin_widget.setIcon(spin_icon)
 
    # simple widget
-   simple_widget = qta.IconWidget('mdi.web', color='blue')
+   simple_widget = qta.IconWidget('mdi.web', color='blue',
+                                  size=QtCore.QSize(16, 16))
 
 Screenshot
 ~~~~~~~~~~

--- a/example.py
+++ b/example.py
@@ -96,7 +96,7 @@ class AwesomeExample(QtWidgets.QDialog):
         lo.addWidget(iconwidget)
         lo.addWidget(QtWidgets.QLabel('IconWidget'))
         iconwidgetholder.setLayout(lo)
-        iconwidget2 = qta.IconWidget('mdi.web', color='blue')
+        iconwidget2 = qta.IconWidget('mdi.web', color='blue', size=QtCore.QSize(24, 24))
 
         # Icon drawn with the `image` option
         drawn_image_icon = qta.icon('ri.truck-fill',

--- a/example.py
+++ b/example.py
@@ -96,7 +96,7 @@ class AwesomeExample(QtWidgets.QDialog):
         lo.addWidget(iconwidget)
         lo.addWidget(QtWidgets.QLabel('IconWidget'))
         iconwidgetholder.setLayout(lo)
-        iconwidget2 = qta.IconWidget('mdi.web', color='blue', size=QtCore.QSize(24, 24))
+        iconwidget2 = qta.IconWidget('mdi.web', color='blue', size=QtCore.QSize(16, 16))
 
         # Icon drawn with the `image` option
         drawn_image_icon = qta.icon('ri.truck-fill',

--- a/qtawesome/__init__.py
+++ b/qtawesome/__init__.py
@@ -334,19 +334,23 @@ class IconWidget(QtWidgets.QLabel):
     """
     IconWidget gives the ability to display an icon as a widget
 
-    if supports the same arguments as icon()
-    for example
-    music_icon = qta.IconWidget('fa5s.music',
-                                color='blue',
-                                color_active='orange')
+    It supports the same arguments as `icon()`,
+    for example,
 
-    it also have setIcon() and setIconSize() functions
+        music_icon = qta.IconWidget('fa5s.music',
+                                    color='blue',
+                                    color_active='orange')
+
+    The exceptions are `parent` and `size` keyword-only arguments,
+    which allow setting the widget parent and initial size, correspondingly.
+
+    It also has `setIcon()` and `setIconSize()` functions.
     """
 
     def __init__(self, *names, **kwargs):
         super().__init__(parent=kwargs.get('parent'))
         self._icon = None
-        self._size = QtCore.QSize(16, 16)
+        self._size = kwargs.get('size', QtCore.QSize(16, 16))
         self.setIcon(icon(*names, **kwargs))
 
     def setIcon(self, _icon):


### PR DESCRIPTION
I suggest adding a `size` keyword-only argument to the constructor of `IconWidget` to avoid extra `setIconSize` and `update` calls.

This way,
```python
icon_widget: qta.IconWidget = qta.IconWidget('mdi.web', color='blue')
icon_widget.setIconSize(QtCore.QSize(32, 32))
icon_widget.update()
```
turns into
```python
icon_widget: qta.IconWidget = qta.IconWidget('mdi.web', color='blue', size=QtCore.QSize(32, 32))
```

---

And I fixed a couple of typos in the docstring of the class.