### PR TITLE
PR: Add `IconWidget` to the docs

### DIFF
--- a/qtawesome/__init__.py
+++ b/qtawesome/__init__.py
@@ -10,6 +10,7 @@ Font-Awesome and other iconic fonts for PyQt / PySide applications.
    :toctree: _generate
 
    icon
+   IconWidget
    load_font
    charmap
    font


### PR DESCRIPTION
Following https://github.com/spyder-ide/qtawesome/pull/238#discussion_r1240461019, I found `IconWidget` missing from the TOC. Unfortunately, it's not the only problem with the docs, for `Spin` and `Pulse` animations are missing, too.

I'm unsure of where to place `IconWidget` in the TOC. So, please feel free to edit the tiniest of the commits.

---

Oh, I've forgotten to update the forked branch.