### PR TITLE
PR: Update `readthedocs` config to version 2

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,3 +6,4 @@ channels:
 dependencies:
 - pyqt
 - qtpy
+- sphinx_rtd_theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,8 +73,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'qtawesome'
-copyright = u'2015, The Spyder Development Team'
-author = u'The Spyder Development Team'
+copyright = u'2015-, The Spyder Development Team'
+author = u'Sylvain Corlay and the Spyder Development Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
+    'sphinx_rtd_theme',
 ]
 
 autosummary_generate = True
@@ -133,7 +134,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-# html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -310,4 +310,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,7 +89,7 @@ release = _release['__version__']
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,6 +8,11 @@ build:
 conda:
   environment: docs/environment.yml
 
+python:
+  install:
+    - method: pip
+      path: .
+
 sphinx:
   builder: html
   configuration: docs/source/conf.py

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,9 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "mambaforge-22.9"
+
 conda:
-    file: docs/environment.yml
-python:
-    version: 3
-    setup_py_install: true
+  environment: docs/environment.yml

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,3 +7,8 @@ build:
 
 conda:
   environment: docs/environment.yml
+
+sphinx:
+  builder: html
+  configuration: docs/source/conf.py
+  fail_on_warning: true


### PR DESCRIPTION
For more info about why the change is needed see: https://blog.readthedocs.com/migrate-configuration-v2/