### PR TITLE
PR: Use GitHub raw content URL to display `README` images over package PyPI landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ animation.stop()
 
 - Screenshot
 
-![QtAwesome screenshot](qtawesome-screenshot.gif)
+![QtAwesome screenshot](https://raw.githubusercontent.com/spyder-ide/qtawesome/master/qtawesome-screenshot.gif)
 
 
 To check these options you can launch the `example.py` script and pass to it the options as arguments. For example, to test how the icons could look using the `glyphrun` draw option, you can run something like:
@@ -214,7 +214,7 @@ name that should be used to create that icon!
 
 Once installed, run `qta-browser` from a shell to start the browser.
 
-![qta-browser](qtawesome-browser.png)
+![qta-browser](https://raw.githubusercontent.com/spyder-ide/qtawesome/master/qtawesome-browser.png)
 
 
 ## License


### PR DESCRIPTION
Need to use GitHub URL to display README images over PyPI. Currently the images are not being loaded:

![image](https://github.com/spyder-ide/qtawesome/assets/16781833/32427e05-6e48-4db3-8e55-1bdcbf0e1b83)
