### PR TITLE
Fix styling on PySide6

### DIFF
--- a/qtawesome/styles.py
+++ b/qtawesome/styles.py
@@ -25,6 +25,7 @@ SOFTWARE.
 """
 
 from qtpy.QtGui import QPalette, QColor
+from qtpy.QtWidgets import QStyleFactory
 
 # Constant to reference default themes
 DEFAULT_DARK_PALETTE = 'Dark'
@@ -76,7 +77,7 @@ def dark(app):
     app.style().unpolish(app)
     app.setPalette(dark_palette)
 
-    app.setStyle('Fusion')
+    app.setStyle(QStyleFactory.create('Fusion'))
 
 
 def light(app):
@@ -124,4 +125,4 @@ def light(app):
     app.style().unpolish(app)
     app.setPalette(light_palette)
 
-    app.setStyle('Fusion')
+    app.setStyle(QStyleFactory.create('Fusion'))


### PR DESCRIPTION
# Issue
`QWidget.setStyle` on PySide6 only accepts a QStyle class, while PyQt5, PyQt6, and PySide2 can accept a QStyle or a string. This causes `qtawesome.dark()` / `qtawesome.light()` to fail on PySide6.

# Change
This change fixes the issue by using `QStyleFactory.create()` to set the application style in `styles.py`