### PR TITLE
PR: For `PySide2`, require `pytest-qt<4.5.0`

### DIFF
--- a/requirements/environment_tests_pyside2.yml
+++ b/requirements/environment_tests_pyside2.yml
@@ -4,5 +4,5 @@ dependencies:
 - pyside2>=5.15
 - pytest
 - pytest-cov
-- pytest-qt
+- pytest-qt<4.5.0
 - qtpy<2.0.0


### PR DESCRIPTION
This is uncharted territory for me, so do please check me.

So, `pytest-qt` have dropped the support for `PySide2` and for `Python<=3.8`. Although the tests are still working even with Python 3.7, `pytest-qt` explicitly fails with `PySide2`. The PR limits `pytest-qt` to be older than 4.5.0.

See https://pytest-qt.readthedocs.io/en/4.5.0/changelog.html#id2.