### PR TITLE
PR: Add Qt6 (PyQt6/PySide6) test jobs and fix PySide2 and `pytest-qt` support related failures

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -18,7 +18,6 @@ jobs:
       QT_API:  ${{ matrix.QT_BINDING }}
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
       RUNNER_OS: 'ubuntu'
-      COVERALLS_REPO_TOKEN: XWVhJf2AsO7iouBLuCsh0pPhwHy81Uz1v
     strategy:
       fail-fast: false
       matrix:
@@ -73,7 +72,6 @@ jobs:
       QT_API:  ${{ matrix.QT_BINDING }}
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
       RUNNER_OS: 'ubuntu'
-      COVERALLS_REPO_TOKEN: XWVhJf2AsO7iouBLuCsh0pPhwHy81Uz1v
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -87,14 +87,11 @@ jobs:
       - name: Install System Packages
         run: |
           sudo apt-get update --fix-missing
-          sudo apt-get install -qq pyqt6-dev-tools libxcb-xinerama0 xterm --fix-missing
-          # The following is to run PyQt6 in a window-less mode.
-          # From https://stackoverflow.com/a/77480795/8554611
-          # Stuff copied wildly from several stackoverflow posts
-          sudo apt-get install -qq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev --fix-missing
-          sudo apt-get install -qq '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev --fix-missing
-          # start xvfb in the background
-          sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
+          sudo apt-get install -qq pyqt6-dev-tools --fix-missing
+      - name: Setup a headless display
+        uses: pyvista/setup-headless-display-action@v3
+        with:
+          qt: true
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -74,6 +74,8 @@ jobs:
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
       RUNNER_OS: 'ubuntu'
       COVERALLS_REPO_TOKEN: XWVhJf2AsO7iouBLuCsh0pPhwHy81Uz1v
+      # Display must be available globally for linux to know where xvfb is
+      DISPLAY: ":99.0"
     strategy:
       fail-fast: false
       matrix:
@@ -86,6 +88,13 @@ jobs:
         run: |
           sudo apt-get update --fix-missing
           sudo apt-get install -qq pyqt6-dev-tools libxcb-xinerama0 xterm --fix-missing
+          # The following is to run PyQt6 in a window-less mode.
+          # From https://stackoverflow.com/a/77480795/8554611
+          # Stuff copied wildly from several stackoverflow posts
+          sudo apt-get install -qq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev --fix-missing
+          sudo apt-get install -qq '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev --fix-missing
+          # start xvfb in the background
+          sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -9,7 +9,7 @@ on:
     - master
 
 jobs:
-  linux:
+  linux-qt5:
     name: Linux Py${{ matrix.PYTHON_VERSION }} - ${{ matrix.QT_BINDING }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
@@ -31,6 +31,61 @@ jobs:
         run: |
           sudo apt-get update --fix-missing
           sudo apt-get install -qq pyqt5-dev-tools libxcb-xinerama0 xterm --fix-missing
+      - name: Install Conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+           activate-environment: test
+           auto-update-conda: false
+           auto-activate-base: false
+           python-version: ${{ matrix.PYTHON_VERSION }}
+           channels: conda-forge
+           channel-priority: strict
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: conda env update --file requirements/environment_tests_${{ matrix.QT_BINDING }}.yml
+      - name: Install Package
+        shell: bash -l {0}
+        run: pip install -e .
+      - name: Show environment information
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+      - name: Run tests
+        shell: bash -l {0}
+        run: |
+          xvfb-run --auto-servernum python example.py
+          xvfb-run --auto-servernum pytest -x -vv --cov-report xml --cov=qtawesome qtawesome
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  linux-qt6:
+    name: Linux Py${{ matrix.PYTHON_VERSION }} - ${{ matrix.QT_BINDING }}
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    env:
+      CI: True
+      QT_API:  ${{ matrix.QT_BINDING }}
+      PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
+      RUNNER_OS: 'ubuntu'
+      COVERALLS_REPO_TOKEN: XWVhJf2AsO7iouBLuCsh0pPhwHy81Uz1v
+    strategy:
+      fail-fast: false
+      matrix:
+        PYTHON_VERSION: ['3.9', '3.13']
+        QT_BINDING: ['pyqt6', 'pyside6']
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+      - name: Install System Packages
+        run: |
+          sudo apt-get update --fix-missing
+          sudo apt-get install -qq pyqt6-dev-tools libxcb-xinerama0 xterm --fix-missing
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -74,8 +74,6 @@ jobs:
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
       RUNNER_OS: 'ubuntu'
       COVERALLS_REPO_TOKEN: XWVhJf2AsO7iouBLuCsh0pPhwHy81Uz1v
-      # Display must be available globally for linux to know where xvfb is
-      DISPLAY: ":99.0"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -9,7 +9,7 @@ on:
     - master
 
 jobs:
-  macos:
+  macos-qt5:
     name: Mac Py${{ matrix.PYTHON_VERSION }} - ${{ matrix.QT_BINDING }}
     timeout-minutes: 15
     runs-on: macos-13
@@ -59,3 +59,52 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  macos-qt6:
+    name: Mac Py${{ matrix.PYTHON_VERSION }} - ${{ matrix.QT_BINDING }}
+    timeout-minutes: 15
+    runs-on: macos-13
+    env:
+      CI: True
+      QT_API:  ${{ matrix.QT_BINDING }}
+      PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
+      RUNNER_OS: 'macos'
+    strategy:
+      fail-fast: false
+      matrix:
+        PYTHON_VERSION: ['3.9', '3.13']
+        QT_BINDING: ['pyqt6', 'pyside6']
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v1
+      - name: Install Conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+           activate-environment: test
+           auto-update-conda: false
+           auto-activate-base: false
+           python-version: ${{ matrix.PYTHON_VERSION }}
+           channels: conda-forge
+           channel-priority: strict
+      - name: Install package dependencies
+        shell: bash -l {0}
+        run: conda env update --file requirements/environment_tests_${{ matrix.QT_BINDING }}.yml
+      - name: Install Package
+        shell: bash -l {0}
+        run: pip install -e .
+      - name: Show environment information
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+      - name: Run tests
+        shell: bash -l {0}
+        run: |
+          python example.py
+          pytest -x -vv --cov-report xml --cov=qtawesome qtawesome
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -9,7 +9,7 @@ on:
     - master
 
 jobs:
-  windows:
+  windows-qt5:
     name: Windows Py${{ matrix.PYTHON_VERSION }} - ${{ matrix.QT_BINDING }}
     timeout-minutes: 15
     runs-on: windows-latest
@@ -59,3 +59,52 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  windows-qt6:
+    name: Windows Py${{ matrix.PYTHON_VERSION }} - ${{ matrix.QT_BINDING }}
+    timeout-minutes: 15
+    runs-on: windows-latest
+    env:
+      CI: True
+      QT_API:  ${{ matrix.QT_BINDING }}
+      PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
+      RUNNER_OS: 'windows'
+    strategy:
+      fail-fast: false
+      matrix:
+        PYTHON_VERSION: ['3.9', '3.13']
+        QT_BINDING: ['pyqt6', 'pyside6']
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v1
+      - name: Install Conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+           activate-environment: test
+           auto-update-conda: false
+           auto-activate-base: false
+           python-version: ${{ matrix.PYTHON_VERSION }}
+           channels: conda-forge
+           channel-priority: strict
+      - name: Install package dependencies
+        shell: bash -l {0}
+        run: conda env update --file requirements/environment_tests_${{ matrix.QT_BINDING }}.yml
+      - name: Install Package
+        shell: bash -l {0}
+        run: pip install -e .
+      - name: Show environment information
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+      - name: Run tests
+        shell: bash -l {0}
+        run: |
+          python example.py
+          pytest -x -vv --cov-report xml --cov=qtawesome qtawesome
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/requirements/environment_tests_pyqt6.yml
+++ b/requirements/environment_tests_pyqt6.yml
@@ -1,8 +1,8 @@
 channels:
   - conda-forge
 dependencies:
-- pyside2>=5.15
+- pyqt6>=6.2,!=6.8.0
 - pytest
 - pytest-cov
-- pytest-qt<4.5.0
-- qtpy<2.0.0
+- pytest-qt
+- qtpy

--- a/requirements/environment_tests_pyqt6.yml
+++ b/requirements/environment_tests_pyqt6.yml
@@ -1,8 +1,10 @@
 channels:
   - conda-forge
 dependencies:
-- pyqt6>=6.2,!=6.8.0
 - pytest
 - pytest-cov
 - pytest-qt
 - qtpy
+- pip
+- pip:
+  - PyQt6>=6.2,!=6.8.0

--- a/requirements/environment_tests_pyside6.yml
+++ b/requirements/environment_tests_pyside6.yml
@@ -1,8 +1,8 @@
 channels:
   - conda-forge
 dependencies:
-- pyside2>=5.15
+- pyside6>=6.2,!=6.8.0,!=6.8.0.1
 - pytest
 - pytest-cov
-- pytest-qt<4.5.0
-- qtpy<2.0.0
+- pytest-qt
+- qtpy


### PR DESCRIPTION
Add tests for PyQt6 and PySide6.
Fix PySide2 test failing due to `pytest-qt` [dropped its support in 4.5.0](https://pytest-qt.readthedocs.io/en/4.5.0/changelog.html#id2).
For Qt5 bindings, Python 3.7 (EOL @ 2023-06-27) remains in the tests, for it mostly works still. I would bump the Python version up as soon as a failure occurs, without wasting time on a fix.