### PR TITLE
PR: Update macOS image label to `macos-15-intel`

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -12,7 +12,7 @@ jobs:
   macos-qt5:
     name: Mac Py${{ matrix.PYTHON_VERSION }} - ${{ matrix.QT_BINDING }} - ${{ matrix.QT_BINDING_VERSION }}
     timeout-minutes: 15
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       CI: True
       QT_API:  ${{ matrix.QT_BINDING }}
@@ -65,7 +65,7 @@ jobs:
   macos-qt6:
     name: Mac Py${{ matrix.PYTHON_VERSION }} - ${{ matrix.QT_BINDING }} - ${{ matrix.QT_BINDING_VERSION }}
     timeout-minutes: 15
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       CI: True
       QT_API:  ${{ matrix.QT_BINDING }}


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/